### PR TITLE
Update client.lua

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -137,6 +137,12 @@ function PedInteraction(entity, data)
             end
         end)
     end
+     if data.faceme then
+        TaskTurnPedToFaceEntity(entity, PlayerPedId(), 1000)
+        Wait(1000)
+        ClearPedTasks(entity)
+        TaskStandStill(entity, 10000)
+    end
     if data.freeze then
         FreezeEntityPosition(entity, true)
     end


### PR DESCRIPTION
Adds parameter for making the npc face player before initiating dialog.

makes it a bit more immersive and also drastically lowers the chance of seeing your character behind the ped you are talking to.

sorry if bad pull request new to this only the changes from 139-144.

Tested it and it works with the freeze option, shouldn't cause the ped to start twitching and ped resumes course after interaction has ended.